### PR TITLE
(NEW FEATURE ✨) make the API generic

### DIFF
--- a/src/match.ts
+++ b/src/match.ts
@@ -1,19 +1,19 @@
 // Dependencies:
-import { SourceFile } from 'typescript';
+import { Node, SourceFile } from 'typescript';
 import { MATCHERS } from './matchers';
 import { traverse } from './traverse';
 import { TSQueryNode, TSQuerySelectorNode } from './tsquery-types';
 
-export function match (ast: SourceFile, selector: TSQuerySelectorNode): Array<TSQueryNode> {
-    const ancestry: Array<TSQueryNode> = [];
-    const results: Array<TSQueryNode> = [];
+export function match<T extends Node = Node> (ast: SourceFile, selector: TSQuerySelectorNode): Array<TSQueryNode<T>> {
+    const ancestry: Array<TSQueryNode<T>> = [];
+    const results: Array<TSQueryNode<T>> = [];
     if (!selector) {
         return results;
     }
 
     const altSubjects = subjects(selector);
     traverse(ast, {
-        enter (node: TSQueryNode, parent: TSQueryNode | null): void {
+        enter (node: TSQueryNode<T>, parent: TSQueryNode<T> | null): void {
             if (parent != null) {
                 ancestry.unshift(parent);
             }
@@ -41,7 +41,7 @@ export function match (ast: SourceFile, selector: TSQuerySelectorNode): Array<TS
     return results;
 }
 
-export function findMatches (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode> = []): boolean {
+export function findMatches<T extends Node = Node> (node: TSQueryNode<T>, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode<T>> = []): boolean {
     if (!selector) {
         return true;
     }
@@ -57,7 +57,7 @@ export function findMatches (node: TSQueryNode, selector: TSQuerySelectorNode, a
     throw new Error(`Unknown selector type: ${selector.type}`);
 }
 
-function subjects (selector?: TSQuerySelectorNode, ancestor?: TSQueryNode | TSQuerySelectorNode): Array<any> {
+function subjects<T extends Node> (selector?: TSQuerySelectorNode, ancestor?: TSQueryNode<T> | TSQuerySelectorNode): Array<any> {
     if (selector == null || typeof selector !== 'object') {
         return [];
     }

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,5 +1,5 @@
 // Dependencies:
-import { SourceFile, SyntaxKind } from 'typescript';
+import { Node, SourceFile, SyntaxKind } from 'typescript';
 import { TSQueryNode, TSQueryTraverseOptions } from './tsquery-types';
 
 // Constants:
@@ -15,14 +15,14 @@ const LITERAL_KINDS: Array<SyntaxKind> = [
     SyntaxKind.TrueKeyword
 ];
 
-export function traverse (node: SourceFile | TSQueryNode, options: TSQueryTraverseOptions): void {
-    addProperties(node as TSQueryNode);
-    options.enter(node as TSQueryNode, node.parent as TSQueryNode || null);
-    node.forEachChild(child => traverse(child as TSQueryNode, options));
-    options.leave(node as TSQueryNode, node.parent as TSQueryNode || null);
+export function traverse<T extends Node = Node> (node: SourceFile | TSQueryNode<T>, options: TSQueryTraverseOptions<T>): void {
+    addProperties(node as TSQueryNode<T>);
+    options.enter(node as TSQueryNode<T>, node.parent as TSQueryNode<T> || null);
+    node.forEachChild(child => traverse(child as TSQueryNode<T>, options));
+    options.leave(node as TSQueryNode<T>, node.parent as TSQueryNode<T> || null);
 }
 
-export function getVisitorKeys (node: TSQueryNode | null): Array<string> {
+export function getVisitorKeys<T extends Node = Node> (node: TSQueryNode<T> | null): Array<string> {
     return !!node ? Object.keys(node)
     .filter(key => !FILTERED_KEYS.includes(key))
     .filter(key => {

--- a/src/tsquery-types.ts
+++ b/src/tsquery-types.ts
@@ -2,12 +2,12 @@
 import { Node, SourceFile } from 'typescript';
 
 export type TSQueryApi = {
-   (ast: SourceFile, selector: string): Array<TSQueryNode>;
+   <T extends Node = Node>(ast: SourceFile, selector: string): Array<TSQueryNode<T>>;
    ast (text: string, fileName?: string): SourceFile;
-   match (ast: SourceFile, selector: TSQuerySelectorNode): Array<TSQueryNode>;
+   match<T extends Node = Node> (ast: SourceFile, selector: TSQuerySelectorNode): Array<TSQueryNode<T>>;
    matches (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean;
    parse (selector: string): TSQuerySelectorNode;
-   query (ast: SourceFile, selector: string): Array<TSQueryNode>;
+   query<T extends Node = Node> (ast: SourceFile, selector: string): Array<TSQueryNode<T>>;
 };
 
 export type TSQueryAttributeOperatorType = 'regexp' | 'literal' | 'type';
@@ -46,7 +46,7 @@ export type TSQuerySelectorNode = {
     value: TSQuerySelectorNode | RegExp | number | string;
 };
 
-export type TSQueryTraverseOptions = {
-    enter: (node: TSQueryNode, parent: TSQueryNode | null) => void;
-    leave: (node: TSQueryNode, parent: TSQueryNode | null) => void;
+export type TSQueryTraverseOptions<T extends Node> = {
+    enter: (node: TSQueryNode<T>, parent: TSQueryNode<T> | null) => void;
+    leave: (node: TSQueryNode<T>, parent: TSQueryNode<T> | null) => void;
 };

--- a/src/tsquery.ts
+++ b/src/tsquery.ts
@@ -1,6 +1,6 @@
 // Dependencies:
 import * as esquery from 'esquery';
-import { SourceFile } from 'typescript';
+import { Node, SourceFile } from 'typescript';
 import { match } from './match';
 import { TSQueryNode, TSQuerySelectorNode } from './tsquery-types';
 
@@ -8,6 +8,6 @@ export function parse (selector: string): TSQuerySelectorNode {
     return esquery.parse(selector);
 }
 
-export function query (ast: SourceFile, selector: string): Array<TSQueryNode> {
+export function query<T extends Node = Node> (ast: SourceFile, selector: string): Array<TSQueryNode<T>> {
     return match(ast, parse(selector));
 }


### PR DESCRIPTION
Building on top of #1, this makes the API accept a generic type parameter that specifies the type of the returned nodes, so you can now do stuff like:

```typescript
import { ParameterDeclaration } from 'typescript';

// ... 

const result = tsquery<ParameterDeclaration>(sourceFile, 'Constructor Parameter');
```

and result with be of type `TSQueryNode<ParameterDeclaration>[]`.