### PR TITLE
(TOOLING 🔨) fix typescript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "lib": [
-        "ES2017",
-        "DOM"
+      "es2017",
     ],
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
- remove the DOM library
- change "ES2017" to lowercase

This makes sure we don't accidentally access DOM methods inside the library. Also, the values for "lib" should be lowercase (according to VSCode linter)