### PR TITLE
(DOCUMENTATION 📚) - add repository info to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "author": "Craig Spence <craigspence0@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phenomnomnominal/tsquery"
+  },
   "license": "MIT",
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
This will link the [npm package page]() to this github repo, making it easier for users of the package to locate the source code for it (and also contribute!)
