### PR TITLE
Traverse JSDoc nodes if present

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,5 +1,5 @@
 // Dependencies:
-import { Node, SyntaxKind } from 'typescript';
+import { JSDoc, Node, SyntaxKind } from 'typescript';
 import { syntaxKindName } from './syntax-kind';
 import { TSQueryNode, TSQueryTraverseOptions } from './tsquery-types';
 
@@ -27,6 +27,9 @@ const PARSERS: { [key: number]: (node: TSQueryNode) => any } = {
 export function traverse (node: Node | TSQueryNode, options: TSQueryTraverseOptions): void {
     addProperties(node as TSQueryNode);
     options.enter(node as TSQueryNode, node.parent as TSQueryNode || null);
+    if ((node as any).jsDoc) {
+        ((node as any).jsDoc as Array<JSDoc>).forEach(child => traverse(child, options));
+    }
     node.forEachChild(child => traverse(child as TSQueryNode, options));
     options.leave(node as TSQueryNode, node.parent as TSQueryNode || null);
 }

--- a/test/attribute.spec.ts
+++ b/test/attribute.spec.ts
@@ -2,7 +2,7 @@
 import { expect } from './index';
 
 // Dependencies:
-import { BinaryExpression, Block, CallExpression, ExpressionStatement, FunctionDeclaration, IfStatement, VariableDeclaration, VariableStatement } from 'typescript';
+import { BinaryExpression, Block, CallExpression, ExpressionStatement, FunctionDeclaration, IfStatement, VariableDeclaration, VariableStatement, JSDoc, JSDocParameterTag } from 'typescript';
 import { conditional, simpleFunction, simpleProgram } from './fixtures';
 
 // Under test:
@@ -69,9 +69,10 @@ describe('tsquery:', () => {
             const result = tsquery(ast, '[name=/x|foo/]');
 
             expect(result).to.deep.equal([
+                (((ast.statements[0] as any).jsDoc as JSDoc[])[0].tags![0] as JSDocParameterTag).name,
                 (ast.statements[0] as FunctionDeclaration).name,
                 (ast.statements[0] as FunctionDeclaration).parameters[0].name,
-                (((((ast.statements[0] as FunctionDeclaration).body as Block).statements[0] as VariableStatement).declarationList.declarations[0] as VariableDeclaration).initializer as BinaryExpression).left
+                (((((ast.statements[0] as FunctionDeclaration).body as Block).statements[0] as VariableStatement).declarationList.declarations[0] as VariableDeclaration).initializer as BinaryExpression).left,
             ]);
         });
 

--- a/test/fixtures/simple-function.ts
+++ b/test/fixtures/simple-function.ts
@@ -1,5 +1,9 @@
 export const simpleFunction = `
 
+/**
+ * @param x - the x
+ * @param y - the y
+ */
 function foo (x, y) {
     var z = x + y;
     z++;

--- a/test/wildcard.spec.ts
+++ b/test/wildcard.spec.ts
@@ -25,7 +25,7 @@ describe('tsquery:', () => {
         it('should find all nodes (simple function)', () => {
             const result = tsquery(tsquery.ast(simpleFunction), '*');
 
-            expect(result.length).to.equal(22);
+            expect(result.length).to.equal(27);
         });
 
         it('should find all nodes (simple program)', () => {


### PR DESCRIPTION
Fixes #18

This change has two open questions that manifest as ugly code:

1. The jsDoc property is not exposed in the Typescript API because the intended interface is `getJSDocTags`, which does a lot more work to provide a list of tags that are collected directly from a node, or any one of several parent nodes. I use type assertions to any to access the property without checking.
2. The jsDoc property is of type JSDoc[], not Node, so it can't be traversed directly. I decided to add the discovered JSDoc nodes as children before the actual children, since that's where JSDoc appears syntactically. But it's odd that that each tag appears as an individual child instead of appearing under some synthetic jsdoc node.  Unfortunately, I don't know tsquery well enough to know if such a synthetic node is possible, or a good idea.

Both problems boil down to "JSDoc is stored on a side-band to the AST", which leads to problems parsing and representing it as part of the AST. Given (1) my inexperience with tsquery and (2) my hacky solutions to the two open questions, you should probably think of this PR as a starting point for discussion rather than something to merge.