### PR TITLE
Refactor to avoid mutating TypeScript nodes

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -1,9 +1,9 @@
 // Dependencies:
 import { Node, SourceFile, transform, TransformationContext, Transformer, TransformerFactory, visitEachChild,  visitNode } from 'typescript';
 import { query } from './query';
-import { TSQueryNode, TSQueryNodeTransformer, TSQueryOptions } from './tsquery-types';
+import { TSQueryNodeTransformer, TSQueryOptions } from './tsquery-types';
 
-export function map <T extends Node = Node> (ast: SourceFile, selector: string, nodeTransformer: TSQueryNodeTransformer<T>, options: TSQueryOptions = {}): SourceFile {
+export function map (ast: SourceFile, selector: string, nodeTransformer: TSQueryNodeTransformer, options: TSQueryOptions = {}): SourceFile {
     // TODO: Doing map like this means the full tree is visited twice.
     // It might be better to change `query()` to use `transform()`,
     // but with a noop?
@@ -13,12 +13,12 @@ export function map <T extends Node = Node> (ast: SourceFile, selector: string, 
     return transformed as SourceFile;
 }
 
-function createTransformer <T extends Node = Node> (results: Array<TSQueryNode>, nodeTransformer: TSQueryNodeTransformer<T>): TransformerFactory<Node | TSQueryNode> {
-    return function (context: TransformationContext): Transformer<Node | TSQueryNode> {
-        return function (rootNode: Node | TSQueryNode): Node | TSQueryNode {
+function createTransformer (results: Array<Node>, nodeTransformer: TSQueryNodeTransformer): TransformerFactory<Node> {
+    return function (context: TransformationContext): Transformer<Node> {
+        return function (rootNode: Node): Node {
             function visit (node: Node): Node {
-                if (results.includes(node as TSQueryNode)) {
-                    const replacement = nodeTransformer(node as TSQueryNode);
+                if (results.includes(node)) {
+                    const replacement = nodeTransformer(node);
                     return replacement ? replacement : node;
                 }
                 return visitEachChild(node, visit, context);

--- a/src/match.ts
+++ b/src/match.ts
@@ -2,24 +2,24 @@
 import { Node } from 'typescript';
 import { MATCHERS } from './matchers';
 import { traverseChildren } from './traverse';
-import { TSQueryNode, TSQueryOptions, TSQuerySelectorNode } from './tsquery-types';
+import { TSQueryOptions, TSQuerySelectorNode } from './tsquery-types';
 
-export function match <T extends Node = Node> (node: Node | TSQueryNode<T>, selector: TSQuerySelectorNode, options: TSQueryOptions = {}): Array<TSQueryNode<T>> {
-    const results: Array<TSQueryNode<T>> = [];
+export function match <T extends Node = Node> (node: Node, selector: TSQuerySelectorNode, options: TSQueryOptions = {}): Array<T> {
+    const results: Array<T> = [];
     if (!selector) {
         return results;
     }
 
-    traverseChildren(node, (childNode: TSQueryNode, ancestry: Array<TSQueryNode>) => {
+    traverseChildren(node, (childNode: Node, ancestry: Array<Node>) => {
         if (findMatches(childNode, selector, ancestry, options)) {
-            results.push(childNode as TSQueryNode<T>);
+            results.push(childNode as T);
         }
     }, options);
 
     return results;
 }
 
-export function findMatches (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode> = [], options: TSQueryOptions = {}): boolean {
+export function findMatches (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node> = [], options: TSQueryOptions = {}): boolean {
     if (!selector) {
         return true;
     }

--- a/src/matchers/attribute.ts
+++ b/src/matchers/attribute.ts
@@ -1,5 +1,6 @@
 // Dependencies:
-import { TSQueryAttributeOperators, TSQueryAttributeOperatorType, TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { Node } from 'typescript';
+import { TSQueryAttributeOperators, TSQueryAttributeOperatorType, TSQuerySelectorNode } from '../tsquery-types';
 import { getPath } from '../utils';
 
 // Constants:
@@ -12,7 +13,7 @@ const OPERATOR: TSQueryAttributeOperators = {
     '>': greaterThan
 };
 
-export function attribute (node: TSQueryNode, selector: TSQuerySelectorNode): boolean {
+export function attribute (node: Node, selector: TSQuerySelectorNode): boolean {
     const obj: any = getPath(node, selector.name);
 
     // Bail on undefined but *not* if value is explicitly `null`:

--- a/src/matchers/child.ts
+++ b/src/matchers/child.ts
@@ -1,8 +1,9 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function child (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function child (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     if (findMatches(node, selector.right, ancestry)) {
         return findMatches(ancestry[0], selector.left, ancestry.slice(1));
     }

--- a/src/matchers/class.ts
+++ b/src/matchers/class.ts
@@ -1,6 +1,7 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { getProperties } from '../traverse';
-import { TSQueryMatchers, TSQueryNode, TSQueryOptions, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQueryMatchers, TSQueryOptions, TSQuerySelectorNode } from '../tsquery-types';
 
 // Constants:
 const CLASS_MATCHERS: TSQueryMatchers = {
@@ -11,7 +12,7 @@ const CLASS_MATCHERS: TSQueryMatchers = {
     statement
 };
 
-export function classs (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>, options: TSQueryOptions): boolean {
+export function classs (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>, options: TSQueryOptions): boolean {
     if (!getProperties(node).kindName) {
         return false;
     }
@@ -24,28 +25,28 @@ export function classs (node: TSQueryNode, selector: TSQuerySelectorNode, ancest
     throw new Error(`Unknown class name: ${selector.name}`);
 }
 
-function declaration (node: TSQueryNode): boolean {
+function declaration (node: Node): boolean {
     return getProperties(node).kindName.endsWith('Declaration');
 }
 
-function expression (node: TSQueryNode): boolean {
+function expression (node: Node): boolean {
     const { kindName } = getProperties(node);
     return kindName.endsWith('Expression') ||
         kindName.endsWith('Literal') ||
-        (kindName === 'Identifier' && !!node.parent && getProperties(node.parent as TSQueryNode).kindName !== 'MetaProperty') ||
+        (kindName === 'Identifier' && !!node.parent && getProperties(node.parent).kindName !== 'MetaProperty') ||
         kindName === 'MetaProperty';
 }
 
-function fn (node: TSQueryNode): boolean {
+function fn (node: Node): boolean {
     const { kindName } = getProperties(node);
     return kindName.startsWith('Function') ||
         kindName === 'ArrowFunction';
 }
 
-function pattern (node: TSQueryNode): boolean {
+function pattern (node: Node): boolean {
     return getProperties(node).kindName.endsWith('Pattern') || expression(node);
 }
 
-function statement (node: TSQueryNode): boolean {
+function statement (node: Node): boolean {
     return getProperties(node).kindName.endsWith('Statement') || declaration(node);
 }

--- a/src/matchers/class.ts
+++ b/src/matchers/class.ts
@@ -1,4 +1,5 @@
 // Dependencies:
+import { getProperties } from '../traverse';
 import { TSQueryMatchers, TSQueryNode, TSQueryOptions, TSQuerySelectorNode } from '../tsquery-types';
 
 // Constants:
@@ -11,7 +12,7 @@ const CLASS_MATCHERS: TSQueryMatchers = {
 };
 
 export function classs (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>, options: TSQueryOptions): boolean {
-    if (!node.kindName) {
+    if (!getProperties(node).kindName) {
         return false;
     }
 
@@ -24,27 +25,27 @@ export function classs (node: TSQueryNode, selector: TSQuerySelectorNode, ancest
 }
 
 function declaration (node: TSQueryNode): boolean {
-    return node.kindName.endsWith('Declaration');
+    return getProperties(node).kindName.endsWith('Declaration');
 }
 
 function expression (node: TSQueryNode): boolean {
-    const { kindName } = node;
+    const { kindName } = getProperties(node);
     return kindName.endsWith('Expression') ||
         kindName.endsWith('Literal') ||
-        (kindName === 'Identifier' && !!node.parent && (node.parent as TSQueryNode).kindName !== 'MetaProperty') ||
+        (kindName === 'Identifier' && !!node.parent && getProperties(node.parent as TSQueryNode).kindName !== 'MetaProperty') ||
         kindName === 'MetaProperty';
 }
 
 function fn (node: TSQueryNode): boolean {
-    const { kindName } = node;
+    const { kindName } = getProperties(node);
     return kindName.startsWith('Function') ||
         kindName === 'ArrowFunction';
 }
 
 function pattern (node: TSQueryNode): boolean {
-    return node.kindName.endsWith('Pattern') || expression(node);
+    return getProperties(node).kindName.endsWith('Pattern') || expression(node);
 }
 
 function statement (node: TSQueryNode): boolean {
-    return node.kindName.endsWith('Statement') || declaration(node);
+    return getProperties(node).kindName.endsWith('Statement') || declaration(node);
 }

--- a/src/matchers/descendant.ts
+++ b/src/matchers/descendant.ts
@@ -1,8 +1,9 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function descendant (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function descendant (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     if (findMatches(node, selector.right, ancestry)) {
         return ancestry.some((ancestor, index) => {
             return findMatches(ancestor, selector.left, ancestry.slice(index + 1));

--- a/src/matchers/field.ts
+++ b/src/matchers/field.ts
@@ -1,8 +1,9 @@
 // Dependencies:
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { Node } from 'typescript';
+import { TSQuerySelectorNode } from '../tsquery-types';
 import { inPath } from '../utils';
 
-export function field (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function field (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     const path = selector.name.split('.');
     const ancestor = ancestry[path.length - 1];
     return inPath(node, ancestor, path);

--- a/src/matchers/has.ts
+++ b/src/matchers/has.ts
@@ -1,12 +1,13 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
 import { traverseChildren } from '../traverse';
-import { TSQueryNode, TSQueryOptions, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQueryOptions, TSQuerySelectorNode } from '../tsquery-types';
 
-export function has (node: TSQueryNode, selector: TSQuerySelectorNode, _: Array<TSQueryNode>, options: TSQueryOptions): boolean {
-    const collector: Array<TSQueryNode> = [];
+export function has (node: Node, selector: TSQuerySelectorNode, _: Array<Node>, options: TSQueryOptions): boolean {
+    const collector: Array<Node> = [];
     selector.selectors.forEach(childSelector => {
-        traverseChildren(node, (childNode: TSQueryNode, ancestry: Array<TSQueryNode>) => {
+        traverseChildren(node, (childNode: Node, ancestry: Array<Node>) => {
             if (findMatches(childNode, childSelector, ancestry)) {
                 collector.push(childNode);
             }

--- a/src/matchers/identifier.ts
+++ b/src/matchers/identifier.ts
@@ -1,7 +1,8 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { syntaxKindName } from '../syntax-kind';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function identifier (node: TSQueryNode, selector: TSQuerySelectorNode): boolean {
+export function identifier (node: Node, selector: TSQuerySelectorNode): boolean {
     return syntaxKindName(node.kind).toLowerCase() === (selector.value as string).toLowerCase();
 }

--- a/src/matchers/matches.ts
+++ b/src/matchers/matches.ts
@@ -1,9 +1,10 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function matches (modifier: 'some' | 'every'): (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>) => boolean {
-    return function (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function matches (modifier: 'some' | 'every'): (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>) => boolean {
+    return function (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
         return selector.selectors[modifier](childSelector => {
             return findMatches(node, childSelector, ancestry);
         });

--- a/src/matchers/not.ts
+++ b/src/matchers/not.ts
@@ -1,8 +1,9 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function not (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function not (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     return !selector.selectors.some(childSelector => {
         return findMatches(node, childSelector, ancestry);
     });

--- a/src/matchers/nth-child.ts
+++ b/src/matchers/nth-child.ts
@@ -1,24 +1,25 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
 import { getVisitorKeys } from '../traverse';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function nthChild (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function nthChild (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     return findMatches(node, selector.right, ancestry) &&
         findNthChild(node, ancestry, () => (selector.index.value as number) - 1);
 }
 
-export function nthLastChild (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function nthLastChild (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     return findMatches(node, selector.right, ancestry) &&
         findNthChild(node, ancestry, (length: number) => length - (selector.index.value as number));
 }
 
-function findNthChild (node: TSQueryNode, ancestry: Array<TSQueryNode>, getIndex: (length: number) => number): boolean {
+function findNthChild (node: Node, ancestry: Array<Node>, getIndex: (length: number) => number): boolean {
     const [parent] = ancestry;
     if (!parent) {
         return false;
     }
-    const keys = getVisitorKeys(node.parent as TSQueryNode || null);
+    const keys = getVisitorKeys(node.parent || null);
     return keys.some(key => {
         const prop = (node.parent as any)[key];
         if (Array.isArray(prop)) {

--- a/src/matchers/sibling.ts
+++ b/src/matchers/sibling.ts
@@ -1,9 +1,10 @@
 // Dependencies:
+import { Node } from 'typescript';
 import { findMatches } from '../match';
 import { getVisitorKeys } from '../traverse';
-import { TSQueryNode, TSQuerySelectorNode } from '../tsquery-types';
+import { TSQuerySelectorNode } from '../tsquery-types';
 
-export function sibling (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function sibling (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     return findMatches(node, selector.right, ancestry) &&
         findSibling(node, ancestry, siblingLeft) ||
         selector.left.subject &&
@@ -11,19 +12,19 @@ export function sibling (node: TSQueryNode, selector: TSQuerySelectorNode, ances
         findSibling(node, ancestry, siblingRight);
 
     function siblingLeft (prop: any, index: number): boolean {
-        return prop.slice(0, index).some((precedingSibling: TSQueryNode) => {
+        return prop.slice(0, index).some((precedingSibling: Node) => {
             return findMatches(precedingSibling, selector.left, ancestry);
         });
     }
 
     function siblingRight (prop: any, index: number): boolean {
-        return prop.slice(index, prop.length).some((followingSibling: TSQueryNode) => {
+        return prop.slice(index, prop.length).some((followingSibling: Node) => {
             return findMatches(followingSibling, selector.right, ancestry);
         });
     }
 }
 
-export function adjacent (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>): boolean {
+export function adjacent (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>): boolean {
     return findMatches(node, selector.right, ancestry) &&
         findSibling(node, ancestry, adjacentLeft) ||
         selector.right.subject &&
@@ -39,13 +40,13 @@ export function adjacent (node: TSQueryNode, selector: TSQuerySelectorNode, ance
     }
 }
 
-function findSibling (node: TSQueryNode, ancestry: Array<TSQueryNode>, test: (prop: any, index: number) => boolean): boolean {
+function findSibling (node: Node, ancestry: Array<Node>, test: (prop: any, index: number) => boolean): boolean {
     const [parent] = ancestry;
     if (!parent) {
         return false;
     }
 
-    const keys = getVisitorKeys(node.parent as TSQueryNode || null);
+    const keys = getVisitorKeys(node.parent || null);
     return keys.some(key => {
         const prop = (node.parent as any)[key];
         if (Array.isArray(prop)) {

--- a/src/query.ts
+++ b/src/query.ts
@@ -3,9 +3,9 @@ import { Node } from 'typescript';
 import { createAST } from './ast';
 import { match } from './match';
 import { parse } from './parse';
-import { TSQueryNode, TSQueryOptions } from './tsquery-types';
+import { TSQueryOptions } from './tsquery-types';
 
-export function query <T extends Node = Node> (ast: string | Node | TSQueryNode<T>, selector: string, options: TSQueryOptions = {}): Array<TSQueryNode<T>> {
+export function query <T extends Node = Node> (ast: string | Node, selector: string, options: TSQueryOptions = {}): Array<T> {
     if (typeof ast === 'string') {
         ast = createAST(ast);
     }

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -1,11 +1,10 @@
 // Dependencies:
-import { Node } from 'typescript';
 import { query } from './query';
-import { TSQueryNode, TSQueryOptions, TSQueryStringTransformer } from './tsquery-types';
+import { TSQueryOptions, TSQueryStringTransformer } from './tsquery-types';
 
-export function replace <T extends Node = Node> (source: string, selector: string, stringTransformer: TSQueryStringTransformer<T>, options: TSQueryOptions = {}): string {
+export function replace (source: string, selector: string, stringTransformer: TSQueryStringTransformer, options: TSQueryOptions = {}): string {
     const matches = query(source, selector, options);
-    const replacements = matches.map(node => stringTransformer(node as TSQueryNode));
+    const replacements = matches.map(node => stringTransformer(node));
     const reversedMatches = matches.reverse();
     const reversedReplacements = replacements.reverse();
     let result = source;

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,7 +1,7 @@
 // Dependencies:
 import { Node, SyntaxKind } from 'typescript';
 import { syntaxKindName } from './syntax-kind';
-import { TSQueryNode, TSQueryOptions, TSQueryTraverseOptions } from './tsquery-types';
+import { TSQueryNode, TSQueryOptions, TSQueryProperties, TSQueryTraverseOptions } from './tsquery-types';
 
 // Constants:
 const FILTERED_KEYS: Array<string> = ['parent'];
@@ -14,13 +14,13 @@ const LITERAL_KINDS: Array<SyntaxKind> = [
     SyntaxKind.StringLiteral,
     SyntaxKind.TrueKeyword
 ];
-const PARSERS: { [key: number]: (node: TSQueryNode) => any } = {
+const PARSERS: { [key: number]: (properties: TSQueryProperties) => any } = {
     [SyntaxKind.FalseKeyword]: () => false,
-    [SyntaxKind.NoSubstitutionTemplateLiteral]: (node: TSQueryNode) => node.text,
+    [SyntaxKind.NoSubstitutionTemplateLiteral]: (properties: TSQueryProperties) => properties.text,
     [SyntaxKind.NullKeyword]: () => null,
-    [SyntaxKind.NumericLiteral]: (node: TSQueryNode) => +node.text,
-    [SyntaxKind.RegularExpressionLiteral]: (node: TSQueryNode) => new RegExp(node.text),
-    [SyntaxKind.StringLiteral]: (node: TSQueryNode) => node.text,
+    [SyntaxKind.NumericLiteral]: (properties: TSQueryProperties) => +properties.text,
+    [SyntaxKind.RegularExpressionLiteral]: (properties: TSQueryProperties) => new RegExp(properties.text),
+    [SyntaxKind.StringLiteral]: (properties: TSQueryProperties) => properties.text,
     [SyntaxKind.TrueKeyword]: () => true
 };
 
@@ -41,7 +41,6 @@ export function traverseChildren (node: Node | TSQueryNode, iterator: (childNode
 }
 
 function traverse (node: Node | TSQueryNode, traverseOptions: TSQueryTraverseOptions): void {
-    addProperties(node as TSQueryNode);
     traverseOptions.enter(node as TSQueryNode, node.parent as TSQueryNode || null);
     if (traverseOptions.visitAllChildren) {
         node.getChildren().forEach(child => traverse(child as TSQueryNode, traverseOptions));
@@ -60,24 +59,26 @@ export function getVisitorKeys (node: TSQueryNode | null): Array<string> {
     }) : [];
 }
 
-export function addProperties (node: TSQueryNode): void {
-    if (isNotSet(node, 'kindName')) {
-        node.kindName = syntaxKindName(node.kind);
-    }
+const propertiesMap = new WeakMap<TSQueryNode, TSQueryProperties>();
 
-    if (isNotSet(node, 'text')) {
-        node.text = node.getText();
+export function getProperties (node: TSQueryNode): TSQueryProperties {
+    let properties = propertiesMap.get(node);
+    if (!properties) {
+        properties = {
+            kindName: syntaxKindName(node.kind),
+            text: hasKey(node, 'text') ? node.text : node.getText()
+        };
+        if (node.kind === SyntaxKind.Identifier) {
+            properties.name = hasKey(node, 'name') ? node.name : properties.text;
+        }
+        if (LITERAL_KINDS.includes(node.kind)) {
+            properties.value = PARSERS[node.kind](properties);
+        }
+        propertiesMap.set(node, properties);
     }
-
-    if (node.kind === SyntaxKind.Identifier && isNotSet(node, 'name')) {
-        node.name = node.text;
-    }
-
-    if (isNotSet(node, 'value') && LITERAL_KINDS.includes(node.kind)) {
-        node.value = PARSERS[node.kind](node);
-    }
+    return properties;
 }
 
-function isNotSet (object: any, property: string): boolean {
-    return object[property] == null;
+function hasKey<K extends { [key: string]: any }> (node: any, property: keyof K): node is K {
+    return node[property] != null;
 }

--- a/src/tsquery-types.ts
+++ b/src/tsquery-types.ts
@@ -1,18 +1,18 @@
 // Dependencies:
 import { Node, SourceFile, SyntaxKind } from 'typescript';
 
-export type TSQueryNodeTransformer<T extends Node = Node> = (node: Node | TSQueryNode<T>) => Node | null | undefined;
-export type TSQueryStringTransformer<T extends Node = Node> = (node: Node | TSQueryNode<T>) => string | null | undefined;
+export type TSQueryNodeTransformer = (node: Node) => Node | null | undefined;
+export type TSQueryStringTransformer = (node: Node) => string | null | undefined;
 
 export type TSQueryApi = {
-   <T extends Node = Node> (ast: string | Node | TSQueryNode<T>, selector: string, options?: TSQueryOptions): Array<TSQueryNode<T>>;
+   <T extends Node = Node> (ast: string | Node, selector: string, options?: TSQueryOptions): Array<T>;
    ast (source: string, fileName?: string): SourceFile;
-   map <T extends Node = Node> (ast: SourceFile, selector: string, nodeTransformer: TSQueryNodeTransformer<T>, options?: TSQueryOptions): SourceFile;
-   match <T extends Node = Node> (ast: Node | TSQueryNode<T>, selector: TSQuerySelectorNode, options?: TSQueryOptions): Array<TSQueryNode<T>>;
+   map (ast: SourceFile, selector: string, nodeTransformer: TSQueryNodeTransformer, options?: TSQueryOptions): SourceFile;
+   match <T extends Node = Node> (ast: Node, selector: TSQuerySelectorNode, options?: TSQueryOptions): Array<T>;
    parse (selector: string, options?: TSQueryOptions): TSQuerySelectorNode;
    project (configFilePath: string): Array<SourceFile>;
-   query <T extends Node = Node> (ast: string | Node | TSQueryNode<T>, selector: string, options?: TSQueryOptions): Array<TSQueryNode<T>>;
-   replace <T extends Node = Node> (source: string, selector: string, stringTransformer: TSQueryStringTransformer<T>, options?: TSQueryOptions): string;
+   query <T extends Node = Node> (ast: string | Node, selector: string, options?: TSQueryOptions): Array<T>;
+   replace (source: string, selector: string, stringTransformer: TSQueryStringTransformer, options?: TSQueryOptions): string;
    syntaxKindName (node: SyntaxKind): string;
 };
 
@@ -22,12 +22,10 @@ export type TSQueryAttributeOperators = {
     [key: string]: TSQueryAttributeOperator
 };
 
-export type TSQueryMatcher = (node: TSQueryNode, selector: TSQuerySelectorNode, ancestry: Array<TSQueryNode>, options: TSQueryOptions) => boolean;
+export type TSQueryMatcher = (node: Node, selector: TSQuerySelectorNode, ancestry: Array<Node>, options: TSQueryOptions) => boolean;
 export type TSQueryMatchers = {
     [key: string]: TSQueryMatcher;
 };
-
-export type TSQueryNode<T extends Node = Node> = T;
 
 export type TSQueryProperties = {
     // We convert the `kind` property to its string name from the `SyntaxKind` enum:
@@ -58,8 +56,8 @@ export type TSQuerySelectorNode = {
     value: TSQuerySelectorNode | RegExp | number | string;
 };
 
-export type TSQueryTraverseOptions <T extends Node = Node> = {
-    enter: (node: TSQueryNode<T>, parent: TSQueryNode<T> | null) => void;
-    leave: (node: TSQueryNode<T>, parent: TSQueryNode<T> | null) => void;
+export type TSQueryTraverseOptions = {
+    enter: (node: Node, parent: Node | null) => void;
+    leave: (node: Node, parent: Node | null) => void;
     visitAllChildren: boolean;
 };

--- a/src/tsquery-types.ts
+++ b/src/tsquery-types.ts
@@ -27,7 +27,9 @@ export type TSQueryMatchers = {
     [key: string]: TSQueryMatcher;
 };
 
-export type TSQueryNode <T extends Node = Node> = T & {
+export type TSQueryNode<T extends Node = Node> = T;
+
+export type TSQueryProperties = {
     // We convert the `kind` property to its string name from the `SyntaxKind` enum:
     // Some nodes have more that one applicable `SyntaxKind`...
     kindName: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 // Dependencies:
 import { Node } from 'typescript';
-import { addProperties } from './traverse';
-import { TSQueryNode } from './tsquery-types';
+import { getProperties } from './traverse';
 
 export function getPath (obj: any, path: string): any {
     const keys = path.split('.');
@@ -10,14 +9,8 @@ export function getPath (obj: any, path: string): any {
         if (obj == null) {
             return obj;
         }
-
-        // HACK: We need to make sure that the extra properties
-        // have been added on nodes that haven't been fully traversed yet...
-        if (['text', 'name', 'kindName'].includes(key)) {
-            addProperties(obj as TSQueryNode);
-        }
-
-        obj = obj[key];
+        const properties: any = obj.getSourceFile ? getProperties(obj) : {};
+        obj = key in properties ? properties[key] : obj[key];
     }
     return obj;
 }

--- a/test/attribute.spec.ts
+++ b/test/attribute.spec.ts
@@ -7,6 +7,7 @@ import { conditional, simpleFunction, simpleProgram } from './fixtures';
 
 // Under test:
 import { tsquery } from '../src/index';
+import { getProperties } from '../src/traverse';
 
 describe('tsquery:', () => {
     describe('tsquery - attribute:', () => {
@@ -119,7 +120,7 @@ describe('tsquery:', () => {
                 (((ast.statements[1] as IfStatement).expression as BinaryExpression).left as BinaryExpression).right,
                 ((ast.statements[1] as IfStatement).elseStatement as IfStatement).expression
             ]);
-            expect(result.every(node => typeof node.value === 'boolean')).to.equal(true);
+            expect(result.every(node => typeof getProperties(node).value === 'boolean')).to.equal(true);
         });
 
         it('should find any nodes with an attribute with a value that is not a specific type', () => {
@@ -130,7 +131,7 @@ describe('tsquery:', () => {
                 (ast.statements[0] as VariableStatement).declarationList.declarations[0].initializer,
                 (((ast.statements[2] as ExpressionStatement).expression as BinaryExpression).right as BinaryExpression).right
             ]);
-            expect(result.every(node => typeof node.value !== 'string')).to.equal(true);
+            expect(result.every(node => typeof getProperties(node).value !== 'string')).to.equal(true);
         });
     });
 });

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -6,6 +6,7 @@ import { ExpressionStatement, NoSubstitutionTemplateLiteral, TaggedTemplateExpre
 
 // Under test:
 import { tsquery } from '../src/index';
+import { getProperties } from '../src/traverse';
 
 describe('tsquery:', () => {
     describe('tsquery - types:', () => {
@@ -14,7 +15,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'StringLiteral');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal('hello');
+            expect(getProperties(result).value).to.equal('hello');
         });
 
         it('should not try to cast a RegExp from inside a String', () => {
@@ -22,7 +23,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'StringLiteral');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal('/t(/');
+            expect(getProperties(result).value).to.equal('/t(/');
         });
 
         it('should not try to cast a RegExp from inside a Template Literal', () => {
@@ -30,7 +31,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'NoSubstitutionTemplateLiteral');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal('/fo(o/');
+            expect(getProperties(result).value).to.equal('/fo(o/');
         });
 
         it('should not try to cast a RegExp from inside a Tagged Template Literal', () => {
@@ -46,7 +47,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'FalseKeyword');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal(false);
+            expect(getProperties(result).value).to.equal(false);
         });
 
         it('should correctly cast a boolean true', () => {
@@ -54,7 +55,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'TrueKeyword');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal(true);
+            expect(getProperties(result).value).to.equal(true);
         });
 
         it('should correctly cast a null', () => {
@@ -62,7 +63,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'NullKeyword');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal(null);
+            expect(getProperties(result).value).to.equal(null);
         });
 
         it('should correctly cast a number', () => {
@@ -70,7 +71,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'NumericLiteral');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value).to.equal(3.3);
+            expect(getProperties(result).value).to.equal(3.3);
         });
 
         it('should correctly cast a RegExp', () => {
@@ -78,7 +79,7 @@ describe('tsquery:', () => {
             const [result] = tsquery(ast, 'RegularExpressionLiteral');
 
             expect(result).to.equal((ast.statements[0] as ExpressionStatement).expression);
-            expect(result.value instanceof RegExp).to.equal(true);
+            expect(getProperties(result).value instanceof RegExp).to.equal(true);
         });
     });
 });


### PR DESCRIPTION
This PR refactors the implementation so that the properties added to TypeScript nodes in the [`addProperties`](https://github.com/phenomnomnominal/tsquery/blob/8fab1840ca06d81f8f7cf4128c4e9c4ddd91a8dc/src/traverse.ts#L63-L79) function are instead stored in a `WeakMap` - using the `Node` as the key.

Also, as the properties are no longer stored in the `Node`, the `TSQueryNode` type is no longer needed - so I've removed it.

Removing `TSQueryNode` is a breaking change, as that type was returned by the public API. However, if the properties are not added to the nodes, it's a breaking change anyway.

Regarding the issue that prompted the PR, I've had difficulty reproducing it - both on my MacBook and on my Windows laptop. I did see the error occur once on my Window machine, but I've been unable to make it happen again, so I cannot verify that the PR fixes the problem.

However, the OP is able to reliably reproduce the problem and has recorded a demonstration [here](https://github.com/cartant/rxjs-tslint-rules/issues/59#issuecomment-433562997) to show that the PR does fix it.

Also, I've had some experience with mutating TypeScript nodes causing problems. For some time, the in-built TSLint rule `no-unused-variable` was the bane of my life - see [this warning](https://github.com/cartant/rxjs-tslint-rules#rules) - and I believe that the problems it causes also stem from node mutation.

Anyway that's enough rambling. I'd be interested to hear your thoughts and whether you'd approach this differently.

PS. Using the PR's distribution, the tests for `rxjs-tslint-etc` and `tslint-etc` all pass.