### PR TITLE
feature: add third argument to createAST for scriptKind of TypeScript

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,6 +1,7 @@
 // Dependencies:
 import { createSourceFile, ScriptTarget, SourceFile } from 'typescript';
 
-export function createAST (source: string, fileName?: string): SourceFile {
-    return createSourceFile(fileName || '', source, ScriptTarget.Latest, true);
+// ScriptKind values : https://github.com/Microsoft/TypeScript/blob/master/src/compiler/types.ts#L4626
+export function createAST (source: string, fileName?: string, scriptKind?: number): SourceFile {
+    return createSourceFile(fileName || '', source, ScriptTarget.Latest, true, scriptKind);
 }

--- a/src/tsquery-types.ts
+++ b/src/tsquery-types.ts
@@ -6,7 +6,7 @@ export type TSQueryStringTransformer<T extends Node = Node> = (node: Node | TSQu
 
 export type TSQueryApi = {
    <T extends Node = Node> (ast: string | Node | TSQueryNode<T>, selector: string, options?: TSQueryOptions): Array<TSQueryNode<T>>;
-   ast (source: string, fileName?: string): SourceFile;
+   ast (source: string, fileName?: string, scriptKind?: number): SourceFile;
    map <T extends Node = Node> (ast: SourceFile, selector: string, nodeTransformer: TSQueryNodeTransformer<T>, options?: TSQueryOptions): SourceFile;
    match <T extends Node = Node> (ast: Node | TSQueryNode<T>, selector: TSQuerySelectorNode, options?: TSQueryOptions): Array<TSQueryNode<T>>;
    parse (selector: string, options?: TSQueryOptions): TSQuerySelectorNode;

--- a/test/ast.spec.ts
+++ b/test/ast.spec.ts
@@ -1,0 +1,18 @@
+// Test Utilities:
+import { expect } from './index';
+
+// Dependencies:
+import { simpleJsxCode } from './fixtures';
+
+// Under test:
+import { tsquery } from '../src/index';
+
+describe('tsquery:', () => {
+    describe('tsquery - jsx:', () => {
+        it('should get a correct AST from jsx code', () => {
+            const ast = tsquery.ast(simpleJsxCode, '', 2);
+
+            expect(ast.statements.length).to.equal(3);
+        });
+    });
+});

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -4,3 +4,4 @@ export * from './siblings';
 export * from './simple-function';
 export * from './simple-program';
 export * from './statement';
+export * from './jsx';

--- a/test/fixtures/jsx.ts
+++ b/test/fixtures/jsx.ts
@@ -1,0 +1,29 @@
+export const simpleJsxCode = `
+
+import React, { Component } from 'react';
+
+class App extends Component {
+  render() {
+    return (
+      <div className="App">
+        <header className="App-header">
+          <p>
+            Edit <code>src/App.js</code> and save to reload.
+          </p>
+          <a
+            className="App-link"
+            href="https://reactjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn React
+          </a>
+        </header>
+      </div>
+    );
+  }
+}
+
+export default App;
+
+`;

--- a/test/project.spec.ts
+++ b/test/project.spec.ts
@@ -9,13 +9,13 @@ describe('tsquery:', () => {
         it('should process a tsconfig.json file', () => {
             const files = tsquery.project('./tsconfig.json');
 
-            expect(files.length).to.equal(80);
+            expect(files.length).to.equal(82);
         });
 
         it('should find a tsconfig.json file in a director', () => {
             const files = tsquery.project('./');
 
-            expect(files.length).to.equal(80);
+            expect(files.length).to.equal(82);
         });
 
         it(`should handle when a path doesn't exist`, () => {


### PR DESCRIPTION
fix #20

Just a simple wrapping.
Internal code of TypeScript detects the scriptKind if a filename is provided.