### PR TITLE
fix(bug 🐛) - support/ignore synthesized nodes

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -66,7 +66,7 @@ export function getProperties (node: Node): TSQueryProperties {
     if (!properties) {
         properties = {
             kindName: syntaxKindName(node.kind),
-            text: hasKey(node, 'text') ? node.text : node.getText()
+            text: hasKey(node, 'text') ? node.text : getTextIfNotSynthesized(node)
         };
         if (node.kind === SyntaxKind.Identifier) {
             properties.name = hasKey(node, 'name') ? node.name : properties.text;
@@ -81,4 +81,13 @@ export function getProperties (node: Node): TSQueryProperties {
 
 function hasKey<K extends { [key: string]: any }> (node: any, property: keyof K): node is K {
     return node[property] != null;
+}
+
+function getTextIfNotSynthesized (node: Node): string {
+    // getText cannot be called on synthesized nodes - those created using
+    // TypeScript's createXxx functions - because its implementation relies
+    // upon a node's position. See:
+    // https://github.com/microsoft/TypeScript/blob/a8bea77d1efe4984e573760770b78486a5488366/src/services/services.ts#L81-L87
+    // https://github.com/microsoft/TypeScript/blob/a685ac426c168a9d8734cac69202afc7cb022408/src/compiler/utilities.ts#L8169-L8173
+    return !(node.pos >= 0) ? '' : node.getText();
 }

--- a/test/attribute.spec.ts
+++ b/test/attribute.spec.ts
@@ -3,6 +3,7 @@ import { expect } from './index';
 
 // Dependencies:
 import { BinaryExpression, Block, CallExpression, ExpressionStatement, FunctionDeclaration, IfStatement, VariableDeclaration, VariableStatement } from 'typescript';
+import * as ts from 'typescript';
 import { conditional, simpleFunction, simpleProgram } from './fixtures';
 
 // Under test:
@@ -61,6 +62,16 @@ describe('tsquery:', () => {
                 ast.statements[1],
                 (ast.statements[1] as IfStatement).elseStatement as IfStatement
             ]);
+        });
+
+        it('should support synthesized nodes', () => {
+            const ast = ts.createVariableStatement(
+                undefined,
+                [ts.createVariableDeclaration('answer', undefined, ts.createLiteral(42))]
+            );
+            const result = tsquery(ast, '[text="answer"]');
+
+            expect(result).to.deep.equal([ast.declarationList.declarations[0].name]);
         });
     });
 


### PR DESCRIPTION
This PR adds a failing test that uses an AST built from synthesized nodes - nodes created using TypeScript's `createXxx` functions. And fixes `traverse` so that attempts to call `getText` on synthesized nodes are not made.

The problem is that `getText` relies upon a node's position and synthesized nodes won't have one.

For me, this is a problem, as the synthesized nodes created by Angular's TypeScript transformers are breaking `tsquery` calls in the transformer that I have created for the RxJS Dev Tools. And that makes me sad. 😭 