### PR TITLE
fix(replace): allow empty string as replacer

### DIFF
--- a/src/replace.ts
+++ b/src/replace.ts
@@ -9,7 +9,7 @@ export function replace (source: string, selector: string, stringTransformer: TS
     const reversedReplacements = replacements.reverse();
     let result = source;
     reversedReplacements.forEach((replacement, index) => {
-        if (replacement) {
+        if (replacement != null) {
             const match = reversedMatches[index];
             result = `${result.substr(0, match.getStart())}${replacement}${result.substr(match.getEnd())}`;
         }

--- a/test/replace.spec.ts
+++ b/test/replace.spec.ts
@@ -59,5 +59,23 @@ console.log('bar');
 
             `.trim());
         });
+
+        it('should replace with an empty string', () => {
+            const text = `
+
+console.log('foo');
+console.log('bar');
+// console.log('baz');
+
+            `.trim();
+            const result = tsquery.replace(text, 'ExpressionStatement:has(Identifier[name="console"])', () => '');
+            expect(result.trim()).to.equal(`
+
+
+
+// console.log('baz');
+
+            `.trim());
+        });
     });
 });


### PR DESCRIPTION
This allows to pass in "" as a replacer for `tsquery.replace`

It is currently not possible to replace `"something"` with `""`