### PR TITLE
Update tsquery.map() contract to match the TypeScript's contract on visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ TSQuery is a port of the ESQuery API for TypeScript! TSQuery allows you to query
 npm install @phenomnomnominal/tsquery --save-dev
 ```
 
+## Upgrading from version 4.x.x to 5.x.x
+- Update all your calls to `tsquery.map()` to make sure they match the new contract. For more information, check https://github.com/phenomnomnominal/tsquery/pull/76.
+
 ## Examples
 
 Say we want to select all instances of an identifier with name "Animal", e.g. the identifier in the `class` declaration, and the identifier in the `extends` declaration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenomnomnominal/tsquery",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Query TypeScript ASTs with the esquery API!",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/map.ts
+++ b/src/map.ts
@@ -18,7 +18,8 @@ function createTransformer (results: Array<Node>, nodeTransformer: TSQueryNodeTr
         return function (rootNode: Node): Node {
             function visit (node: Node): VisitResult<Node> {
                 if (results.includes(node)) {
-                    return nodeTransformer(node);
+                    const replacement = nodeTransformer(node);
+                    return (replacement != node) ? replacement : visitEachChild(node, visit, context);
                 }
                 return visitEachChild(node, visit, context);
             }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,5 +1,5 @@
 // Dependencies:
-import { Node, SourceFile, transform, TransformationContext, Transformer, TransformerFactory, visitEachChild,  visitNode } from 'typescript';
+import { Node, SourceFile, transform, TransformationContext, Transformer, TransformerFactory, visitEachChild,  visitNode, VisitResult } from 'typescript';
 import { query } from './query';
 import { TSQueryNodeTransformer, TSQueryOptions } from './tsquery-types';
 
@@ -16,10 +16,9 @@ export function map (ast: SourceFile, selector: string, nodeTransformer: TSQuery
 function createTransformer (results: Array<Node>, nodeTransformer: TSQueryNodeTransformer): TransformerFactory<Node> {
     return function (context: TransformationContext): Transformer<Node> {
         return function (rootNode: Node): Node {
-            function visit (node: Node): Node {
+            function visit (node: Node): VisitResult<Node> {
                 if (results.includes(node)) {
-                    const replacement = nodeTransformer(node);
-                    return replacement ? replacement : node;
+                    return nodeTransformer(node);
                 }
                 return visitEachChild(node, visit, context);
             }

--- a/src/tsquery-types.ts
+++ b/src/tsquery-types.ts
@@ -1,7 +1,7 @@
 // Dependencies:
-import { Node, ScriptKind, SourceFile, SyntaxKind } from 'typescript';
+import { Node, ScriptKind, SourceFile, SyntaxKind, VisitResult } from 'typescript';
 
-export type TSQueryNodeTransformer = (node: Node) => Node | null | undefined;
+export type TSQueryNodeTransformer = (node: Node) => VisitResult<Node>;
 export type TSQueryStringTransformer = (
   node: Node
 ) => string | null | undefined;

--- a/test/map.spec.ts
+++ b/test/map.spec.ts
@@ -59,12 +59,31 @@ console.log('bar');
 // console.log('baz');
 
             `.trim());
-            const result = tsquery.map(ast, 'Identifier[name="console"]', () => null);
+            const result = tsquery.map(ast, 'Identifier[name="console"]', (node) => node);
             const printer = createPrinter(printerOptions);
             expect(printer.printFile(result).trim()).to.equal(`
 
 console.log('foo');
 console.log('bar');
+// console.log('baz');
+
+            `.trim());
+        });
+
+        it('should handle a removal transformer', () => {
+            const ast = tsquery.ast(`
+
+console.log('foo');
+console.log('bar');
+// console.log('baz');
+
+            `.trim());
+            const result = tsquery.map(ast, 'StringLiteral', () => undefined);
+            const printer = createPrinter(printerOptions);
+            expect(printer.printFile(result).trim()).to.equal(`
+
+console.log();
+console.log();
 // console.log('baz');
 
             `.trim());

--- a/test/map.spec.ts
+++ b/test/map.spec.ts
@@ -88,5 +88,19 @@ console.log();
 
             `.trim());
         });
+
+        it('should visit child nodes whose ancestors also match the selector', () => {
+            const ast = tsquery.ast('label1: label2: 1 + 1'.trim());
+            let count = 0;
+            tsquery.map(ast, 'LabeledStatement', (node) => { ++count; return node; });
+            expect(count).to.equal(2);
+        });
+
+        it('should\'t visit child nodes when an ancestor has been replaced', () => {
+            const ast = tsquery.ast('label1: label2: 1 + 1'.trim());
+            let count = 0;
+            tsquery.map(ast, 'LabeledStatement', () => { ++count; return undefined; });
+            expect(count).to.equal(1);
+        });
     });
 });


### PR DESCRIPTION
Issue: https://github.com/phenomnomnominal/tsquery/issues/75

### What
TypeScript's visitor supports not only replacing a node by another node, but also detaching nodes from the tree. This PR makes the `tsquery.map()` contract to match the TypeScript's visitor contract:
- Visitors return a VisitResult<T> instance, which is `T | T[] | undefined`.
- When a visitor returns the visited node, nothing is changed.
- When a visitor returns a different node or array of nodes, the original node is replaced by the returned value.
- ⚠️ When a visitor returns `undefined`, the node is detached from the tree.

### How
- `TSQueryNodeTransformer` now returns a `VisitResult` instance.
- As the contract now matches the one for TypeScript's visitor, there is no more need to check the transformer result. Just pass the result through.
- Spec has been updated to cover the removal cases.
- Package major version has been updated to reflect the backwards incompatible change.

### ⚠️ Risks ⚠️
This will break compatibility with previous versions of `tsquery.map()`. Upgrading will require to update your code to match the
new contract. **Pay special attention to the implementations using `map` that return nothing**, as the new contract will detach the node from the tree.